### PR TITLE
Separate conda related build in different stage

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,14 +9,13 @@ on:
   pull_request:
 
 jobs:
-  base-images:
-    name: Build and push base images
+  sidecar-images:
+    name: Build and push sidecar images
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
         image:
-        - base
         - d4science-storage
         - oneclient-sidecar
 
@@ -48,19 +47,68 @@ jobs:
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
 
+  base-image:
+    name: Build base image
+    runs-on: ubuntu-latest
+    outputs:
+      base: ${{ steps.docker_meta_base.outputs.tags }}
+      base_conda: ${{ steps.docker_meta_base_conda.outputs.tags }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Docker meta
+        id: docker_meta_base
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ github.repository_owner }}/notebooks-base
+          tags: |
+            type=sha
+      - name: Docker meta
+        id: docker_meta_base_conda
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ github.repository_owner }}/notebooks-base-conda
+          tags:
+            type=sha
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build base
+        uses: docker/build-push-action@v2
+        with:
+          context: base
+          tags: ${{ steps.docker_meta_base.outputs.tags }}
+          labels: ${{ steps.docker_meta_base.outputs.labels }}
+          target: base
+          outputs: type=docker,dest=/tmp/base.tar
+      - name: Build base + conda
+        uses: docker/build-push-action@v2
+        with:
+          context: base
+          tags: ${{ steps.docker_meta_base_conda.outputs.tags }}
+          labels: ${{ steps.docker_meta_base_conda.outputs.labels }}
+          outputs: type=docker,dest=/tmp/base-conda.tar
+      - name: Upload docker image as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: images
+          path: /tmp/base*.tar
+
   user-images:
     name: Build and push images
     runs-on: ubuntu-latest
-    needs: base-images
+    needs: base-image
 
     strategy:
       matrix:
         image:
         - single-user
-        - single-user-d4science
-        - single-user-panosc
-        - single-user-r-d4science
-        - single-user-sobigdata
+        # - single-user-d4science
+        # - single-user-panosc
+        # - single-user-r-d4science
+        # - single-user-sobigdata
 
     steps:
       - name: try to make free space
@@ -77,35 +125,63 @@ jobs:
           images: eginotebooks/${{ matrix.image }}
           tags: |
             type=sha
+      - name: Docker meta
+        id: docker_meta_conda
+        uses: docker/metadata-action@v3
+        with:
+          images: eginotebooks/${{ matrix.image }}-conda
+          tags: |
+            type=sha
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      # this is not very efficient, we are building the same stuff over and over :(
-      - name: Build base image
-        uses: docker/build-push-action@v2
+      - name: Get previous build base
+        uses: actions/download-artifact@v2
         with:
-          context: base
-          push: false
-          tags: ${{ steps.docker_meta.outputs.tags }}
-          labels: ${{ steps.docker_meta.outputs.labels }}
+          name: images
+          path: /tmp
+      - name: Load Docker images
+        run: |
+          docker load --input /tmp/base.tar
+          docker load --input /tmp/base-conda.tar
+          # we are so scarce on storage that this needs to be cleared
+          rm -rf /tmp/base-*.tar
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
         if: github.event_name != 'pull_request'
-      - name: Build
-        uses: docker/build-push-action@v2
-        with:
-          context: ${{ matrix.image }}
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.docker_meta.outputs.tags }}
-          labels: ${{ steps.docker_meta.outputs.labels }}
-          load: ${{ github.event_name == 'pull_request' }}
+      # Unfortunately I haven't been able to load an prebuilt image here
+      # so not using the build-push-action from docker
+      # it's missing the labels and assumes tags is just one
+      - name: Build full image
+        run: |
+          docker build \
+            --build-arg BASE_IMAGE=${{ needs.base-image.outputs.base }} \
+            --build-arg BASE_IMAGE_CONDA=${{ needs.base-image.outputs.base_conda }} \
+            --tag ${{ steps.docker_meta_conda.outputs.tags }} \
+            ${{ matrix.image }}
+      - name: Push full image
+        run: |
+          docker push ${{ steps.docker_meta_conda.outputs.tags }}
+        if: ${{ github.event_name != 'pull_request' }}
+      - name: Build basic image
+        run: |
+          docker build \
+            --build-arg BASE_IMAGE=${{ needs.base-image.outputs.base }} \
+            --build-arg BASE_IMAGE_CONDA=${{ needs.base-image.outputs.base_conda }} \
+            --tag ${{ steps.docker_meta.outputs.tags }} \
+            --target base
+            ${{ matrix.image }}
+      - name: Push base image
+        run: |
+          docker push ${{ steps.docker_meta.outputs.tags }}
+        if: ${{ github.event_name != 'pull_request' }}
       - uses: addnab/docker-run-action@v3
         with:
-          image: ${{ steps.docker_meta.outputs.tags }}
+          image: ${{ steps.docker_meta_conda.outputs.tags }}
           options: -v ${{ github.workspace }}/${{ matrix.image }}:/image-data
           run: |
             for f in /image-data/tests/*.ipynb; do

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,7 +1,8 @@
-# 6d42503c684f has python3.8 needed for samesite setting of cookies
+# notebook-6.4.0 has python3.9
 # Using that to ensure the image remains the same
-FROM jupyter/datascience-notebook:6d42503c684f
+FROM jupyter/datascience-notebook:notebook-6.4.0 as base
 
+# First state deals with the non-conda related stuff
 USER root
 
 RUN apt-get update \
@@ -17,6 +18,11 @@ RUN curl https://raw.githubusercontent.com/kadwanev/retry/master/retry \
          -o /usr/local/bin/retry && chmod +x /usr/local/bin/retry
 
 USER $NB_UID
+
+RUN rmdir work
+
+# Second stage deal with the conda specifics
+FROM base
 
 # install mamba which goes way faster than conda
 RUN conda install mamba -y --quiet -c conda-forge \

--- a/single-user-panosc/Dockerfile
+++ b/single-user-panosc/Dockerfile
@@ -4,7 +4,6 @@ USER $NB_UID
 RUN conda install mamba -y --quiet -c conda-forge 
 RUN mamba install -y  -c onedata protobuf=3.13 fs.onedatafs && conda clean --all
 
-
 # packages not in conda
 RUN pip install --no-cache-dir \
         git+https://github.com/EGI-Foundation/egi-notebooks-addons@0.1.3 \

--- a/single-user/Dockerfile
+++ b/single-user/Dockerfile
@@ -1,8 +1,37 @@
 ARG BASE_IMAGE=eginotebooks/base:latest
+ARG BASE_IMAGE_CONDA=eginotebooks/base-conda:latest
 # hadolint ignore=DL3006
-FROM $BASE_IMAGE
+FROM $BASE_IMAGE as base
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# DIRAC
+USER root
+# CAs do require install-recommends :(
+# hadolint ignore=DL3015
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y gnupg git \
+    && curl http://repository.egi.eu/sw/production/cas/1/current/repo-files/egi-trustanchors.list \
+            -o /etc/apt/sources.list.d/egi-trustanchors.list \
+    && curl https://dl.igtf.net/distribution/igtf/current/GPG-KEY-EUGridPMA-RPM-3 | apt-key add - \
+    && apt-get update \
+    && apt-get install -y ca-policy-egi-core \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p  /etc/dirac
+COPY dirac.cfg /etc/dirac/dirac.cfg
+ENV DIRACSYSCONFIG=/etc/dirac/dirac.cfg
+
+USER $NB_UID
+
+# Second stage: conda
+FROM $BASE_IMAGE_CONDA as conda
+
+FROM base
+
+# Get the conda stuff
+COPY --from=conda /opt /opt
 
 RUN mamba install -y --quiet \
         cftime \
@@ -48,26 +77,6 @@ RUN conda config --add channels bioconda \
         emboss \
     && conda clean --all
 
-# DIRAC
-USER root
-# CAs do require install-recommends :(
-# hadolint ignore=DL3015
-RUN apt-get update \
-    && apt-get install --no-install-recommends -y gnupg git \
-    && curl http://repository.egi.eu/sw/production/cas/1/current/repo-files/egi-trustanchors.list \
-            -o /etc/apt/sources.list.d/egi-trustanchors.list \
-    && curl https://dl.igtf.net/distribution/igtf/current/GPG-KEY-EUGridPMA-RPM-3 | apt-key add - \
-    && apt-get update \
-    && apt-get install -y ca-policy-egi-core \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN mkdir -p  /etc/dirac
-COPY dirac.cfg /etc/dirac/dirac.cfg
-ENV DIRACSYSCONFIG=/etc/dirac/dirac.cfg
-
-USER $NB_UID
-
 RUN mamba create --name dirac -y --quiet -c conda-forge ipython dirac-grid python=2.7 pypy2.7 ipykernel \
     && $(conda run -n dirac /bin/bash -c "which python") -m ipykernel install --prefix /tmp --name DIRAC \
     && jupyter kernelspec install /tmp/share/jupyter/kernels/dirac/ --name DIRAC --prefix /opt/conda \
@@ -81,12 +90,9 @@ RUN mamba create --name dirac -y --quiet -c conda-forge ipython dirac-grid pytho
     && rm -rf /tmp/share \
     && conda clean --all
 
-
 # packages not in conda
 RUN pip install --no-cache-dir \
         git+https://github.com/EGI-Foundation/egi-notebooks-addons@0.1.3 \
         h5glance \
         nbtop \
         tflearn
-
-RUN rmdir work


### PR DESCRIPTION
# Summary

This allows us to have a base image where we care about everything that
is not /opt and then a full image with all the conda stuff. In theory
this /opt in the conda image could be taken out of the image and mounted
in a volume

<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->


<!-- Describe in plain English what this PR does -->

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
