### PR TITLE
Add latest tag for base images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,6 +30,7 @@ jobs:
           images: eginotebooks/${{ matrix.image }}
           tags: |
             type=sha
+            latest
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

We stopped publishing the latest tag for the base image, thus the derivative images are always using a stale and old base image when building

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
