### PR TITLE
Remove build of the Panosc image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -91,7 +91,6 @@ jobs:
         image:
         - single-user
         - single-user-d4science
-        - single-user-panosc
         - single-user-r-d4science
         - single-user-sobigdata
 


### PR DESCRIPTION
installation of fs.onedatafs lib from conda is currently broken ( most probably will be fixed next week)

<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary
The installation of the fs.onedatafs lib via conda is currently broken, it will most probably fixed next week
---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
