### PR TITLE
Enable allow_other in fuse

### DIFF
--- a/oneclient-sidecar/Dockerfile
+++ b/oneclient-sidecar/Dockerfile
@@ -2,4 +2,6 @@ FROM onedata/oneclient:20.02.7
 
 RUN useradd -m -u 1000 -g 100 jovyan
 
+RUN echo "user_allow_other" >> /etc/fuse.conf
+
 USER jovyan

--- a/oneclient-sidecar/Dockerfile
+++ b/oneclient-sidecar/Dockerfile
@@ -1,4 +1,4 @@
-FROM onedata/oneclient:20.02.7
+FROM onedata/oneclient:20.02.15
 
 RUN useradd -m -u 1000 -g 100 jovyan
 


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

Allows to use the -o allow_other with the oneclient. Useful for the binder setup

<!-- Describe in plain English what this PR does -->

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
