### PR TITLE
Pin jinja2 version

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -70,6 +70,7 @@ RUN conda install mamba -y --quiet -c conda-forge \
         notebook==6.4.1 \
         nbclassic==0.2.8 \
         jupyter-server-proxy \
+        jinja2==3.0.3 \
     && conda clean --all
 
 RUN pip install --no-cache-dir \


### PR DESCRIPTION
Solves version issue in the jinja2 dependency:
```Cannot import name 'soft_unicode' from 'markupsafe'```
coming from:
``` jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-leaflet```
