### PR TITLE
Use automatic discovery of conda kernels

### DIFF
--- a/single-user/Dockerfile
+++ b/single-user/Dockerfile
@@ -25,6 +25,7 @@ RUN mamba install -y --quiet \
 	plotly \
 	graphviz \
 	jq \
+        nb_conda_kernels \
     && mamba install -y --quiet pytorch torchvision fastai -c pytorch -c fastai \
     && conda clean --all
 
@@ -43,8 +44,6 @@ RUN apt-get update \
 USER $NB_UID
 
 RUN mamba install -y --quiet octave_kernel=0.32.0 \
-    && SITE_PACKAGES=$(python -c 'import site; print(site.getsitepackages().pop())') \
-    && jupyter kernelspec install "$SITE_PACKAGES/octave_kernel" --name octave --prefix /opt/conda \
     && conda clean --all
 
 # Rstudio
@@ -83,9 +82,6 @@ RUN pip install --no-cache-dir \
 # EMSO
 # python3.7, install on a different environment
 RUN mamba create --name python3.7 -y --quiet -c conda-forge ipython python=3.7 ipykernel libsndfile \
-    && $(conda run -n python3.7 /bin/bash -c "which python") -m ipykernel install --prefix /tmp --name Python-3.7 \
-    && jupyter kernelspec install /tmp/share/jupyter/kernels/python-3.7/ --name Python-3.7 --prefix /opt/conda \
-    && rm -rf /tmp/share \
     && conda clean --all
 
 # Avoid a broken extension to show up


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

Enables the discovery of kernels from conda environments (created by us or the users) as documented in https://z2jh.jupyter.org/en/latest/jupyterhub/customizing/user-environment.html#allow-users-to-create-their-own-conda-environments-for-notebooks

For a nicer display of the options, `--CondaKernelSpecManager.conda_only=true` option in the command line avoids duplication of kernels listed.

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
