### PR TITLE
Pinned version of jupyter-server-proxy

### DIFF
--- a/d4science-base/Dockerfile
+++ b/d4science-base/Dockerfile
@@ -69,7 +69,7 @@ RUN conda install mamba -y --quiet -c conda-forge \
         jupyterlab==3.1.4 \
         notebook==6.4.1 \
         nbclassic==0.2.8 \
-        jupyter-server-proxy \
+        jupyter-server-proxy==3.2.2 \
         jinja2==3.0.3 \
     && conda clean --all
 


### PR DESCRIPTION
Pinned to version `3.2.2` to prevent the installation of `4.0.0`. This is to test if the new version is provoking an update on Jupyter Notebook, which makes servers show a "Password" screen when they are started.