### PR TITLE
Added structify-net library. See SBD#25186. Also: Updated base image

### DIFF
--- a/single-user-sobigdata/Dockerfile
+++ b/single-user-sobigdata/Dockerfile
@@ -7,7 +7,7 @@
 #                        __/ |                                  
 #                       |___/      
 
-ARG BASE_IMAGE=eginotebooks/base:latest
+ARG BASE_IMAGE=eginotebooks/d4science-base:latest
 # hadolint ignore=DL3006
 FROM $BASE_IMAGE
 
@@ -74,7 +74,8 @@ RUN pip install --no-cache-dir \
         XAI-Library \
         convrewriting \
         git+https://github.com/guglielmocola/TwitterMonitorLib_v2.git \
-        pygm
+        pygm \
+        structify-net
 
 # -------------------------------
 # SoBigData ++ specific libraries


### PR DESCRIPTION
Note that the base image is pointing to `d4science-base` in this commit. This is the correct base image for the `Dockerfile`, but the change will have no practical effect, since this was already enforced later in the image building (via GitHub Actions).