### PR TITLE
fix: detect changes when pushing to master

### DIFF
--- a/.github/workflows/build-list.yml
+++ b/.github/workflows/build-list.yml
@@ -26,6 +26,10 @@ jobs:
       matrix: ${{ steps.build.outputs.matrix }}
       build-base: ${{ steps.build.outputs.build-base}}
     steps:
+      - name: Get source code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Change list
         id: change-list
         uses: tj-actions/changed-files@v37

--- a/webdav-sidecar/Dockerfile
+++ b/webdav-sidecar/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.18
 
 ENV MOUNT_PATH=/mnt
 ENV WEBDAV_URL=


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

When pushing to master the workflow failed with:
```
[detect-changes / detect-changes](https://github.com/EGI-Federation/egi-notebooks-images/actions/runs/5528503656/jobs/10085368708#step:2:37)
Can't find local .git directory. Please run actions/checkout before this action
```

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
