### PR TITLE
Upgrade base and single-user image to JupyterHub 5

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,5 +1,12 @@
-# 2022-11-21 is python 3.10.6
-FROM jupyter/datascience-notebook:2022-11-21
+# 2024-07-02
+# hub-5.0.0
+# julia-1.10.4
+# lab-4.2.3
+# notebook-7.2.1
+# python-3.11.9
+# r-4.3.3
+# ubuntu-22.04
+FROM quay.io/jupyter/datascience-notebook:615b8cc01b33
 
 USER root
 
@@ -17,9 +24,7 @@ RUN curl https://raw.githubusercontent.com/kadwanev/retry/master/retry \
 
 USER $NB_UID
 
-# install mamba which goes way faster than conda
-RUN conda install mamba -y --quiet -c conda-forge \
-    && mamba install -y -q \
+RUN mamba install -y -q \
         r-plotly \
         r-gdata \
         rdflib \
@@ -32,11 +37,7 @@ RUN conda install mamba -y --quiet -c conda-forge \
         xarray \
         cartopy \
         ipyleaflet \
-        jupyterlab==3.1.4 \
-        notebook==6.4.1 \
-        nbclassic==0.2.8 \
         jupyter-server-proxy \
-        jinja2==3.0.3 \
     && conda clean --all
 
 RUN pip install --no-cache-dir \

--- a/single-user-ai4pp/Dockerfile
+++ b/single-user-ai4pp/Dockerfile
@@ -66,11 +66,11 @@ RUN pip install --no-cache-dir \
 	tensorflow \
 	jupyter-tensorboard-proxy \
 	mlflow-server-proxy \
-	protobuf==4.21.9 \
+	protobuf==4.21.9
 	# torch==1.12.1+cu113 \
 	# torchvision==0.13.1+cu113 \
 	# torchaudio==0.12.1 \
-	--extra-index-url https://download.pytorch.org/whl/cu113
+	# --extra-index-url https://download.pytorch.org/whl/cu113
 
 ENV LD_LIBRARY_PATH="${CONDA_DIR}/lib:${LD_LIBRARY_PATH}"
 

--- a/single-user-ai4pp/Dockerfile
+++ b/single-user-ai4pp/Dockerfile
@@ -10,11 +10,14 @@ RUN mamba install -y --quiet \
 	cudnn \
         matplotlib \
         lightgbm \
-        eo-learn \
         plotly \
         graphviz \
         jq \
     && conda clean --all
+
+# not installable from mamba for now
+RUN pip install  --no-cache-dir \
+        eo-learn
 
 # Octave, install on a different environment
 # Octave from conda won't build packages
@@ -64,10 +67,10 @@ RUN pip install --no-cache-dir \
 	jupyter-tensorboard-proxy \
 	mlflow-server-proxy \
 	protobuf==4.21.9 \
-	torch==1.12.1+cu113 \
-	torchvision==0.13.1+cu113 \
-	torchaudio==0.12.1 \
-	--extra-index-url https://download.pytorch.org/whl/cu113 	
+	# torch==1.12.1+cu113 \
+	# torchvision==0.13.1+cu113 \
+	# torchaudio==0.12.1 \
+	--extra-index-url https://download.pytorch.org/whl/cu113
 
 ENV LD_LIBRARY_PATH="${CONDA_DIR}/lib:${LD_LIBRARY_PATH}"
 

--- a/single-user/Dockerfile
+++ b/single-user/Dockerfile
@@ -39,6 +39,11 @@ RUN mamba install -y --quiet \
 RUN pip install --no-cache-dir \
         eo-learn
 
+# not installable from mamba for now
+# XXX: problem with dependency: pydantic
+RUN pip install --no-cache-dir \
+        elyra
+
 # See https://github.com/mamba-org/mamba/issues/336
 # pytorch is not installing properly with mamba
 RUN mamba install -y pytorch torchvision torchaudio cpuonly -c pytorch -c anaconda -c conda-forge \

--- a/single-user/Dockerfile
+++ b/single-user/Dockerfile
@@ -31,6 +31,8 @@ RUN mamba install -y --quiet \
         qiskit \
         qiskit-machine-learning \
         dwave-ocean-sdk \
+        # resource usage info in GUI
+        jupyter-resource-usage \
     && conda clean --all
 
 # See https://github.com/mamba-org/mamba/issues/336

--- a/single-user/Dockerfile
+++ b/single-user/Dockerfile
@@ -35,6 +35,10 @@ RUN mamba install -y --quiet \
         jupyter-resource-usage \
     && conda clean --all
 
+# not installable from mamba for now
+RUN pip install --no-cache-dir \
+        eo-learn
+
 # See https://github.com/mamba-org/mamba/issues/336
 # pytorch is not installing properly with mamba
 RUN mamba install -y pytorch torchvision torchaudio cpuonly -c pytorch -c anaconda -c conda-forge \

--- a/single-user/Dockerfile
+++ b/single-user/Dockerfile
@@ -4,11 +4,6 @@ FROM $BASE_IMAGE
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-RUN pip install \
-	PennyLane==0.26.0 \
-	qiskit==0.38.0 \
-	qiskit-machine-learning==0.4.0
-
 RUN mamba install -y --quiet \
         cftime \
         ipympl \
@@ -26,14 +21,16 @@ RUN mamba install -y --quiet \
 	matplotlib \
 	scipy \
 	lightgbm \
-	eo-learn \
 	plotly \
 	graphviz \
 	jq \
 	nb_conda_kernels \
-        dwave-ocean-sdk==5.5.0 \
-        amazon-braket-sdk==1.31.0 \
-	elyra \
+        # quantum SDKs
+        amazon-braket-sdk \
+        PennyLane \
+        qiskit \
+        qiskit-machine-learning \
+        dwave-ocean-sdk \
     && conda clean --all
 
 # See https://github.com/mamba-org/mamba/issues/336

--- a/single-user/tests/julia.ipynb
+++ b/single-user/tests/julia.ipynb
@@ -12,15 +12,15 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.8.3",
+   "display_name": "Julia 1.10.4",
    "language": "julia",
-   "name": "julia-1.8"
+   "name": "julia-1.10"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.8.3"
+   "version": "1.10.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# Summary

Upgrade base image to hub-5.0.0 (lab-4.2.3).

Some components are installed using pip, which could be problematic:
* eo-learn
* elyra

A4PP image will need to be updated. Removed torch component for now to make the project build.

**Related issue :**
