### PR TITLE
Implement waiting for remote parent directory

### DIFF
--- a/webdav-rclone-sidecar/README.md
+++ b/webdav-rclone-sidecar/README.md
@@ -13,16 +13,20 @@ Using environment:
 * WEBDAV\_VENDOR: WebDAV vendor (default: *other*)
 * MOUNT\_OPTS: space separated additional arguments for *rclone mount* command
 * MOUNT\_PATH: mount path (default: */mnt*)
+* MOUNT\_WAIT: wait time for mountpoint in /proc/mounts (default: *20*)
+* MOUNT\_WAIT\_POINT: mountpoint regex to wait for (default: (empty))
 * VFS\_CACHE\_MODE: value for rclone VFS cache mode (off, minimal, writes, full) (default: *full*)
 
 Examples:
 
-    docker run --privileged -it --rm --name oidcmount -v /tmp/webdav:/mnt:shared
+    docker run --privileged -it --rm --name oidcmount -v /tmp/webdav:/mnt:shared \
       -e WEBDAV_URL="$WEBDAV_URL" \
       -e WEBDAV_TOKEN="$(oidc-token my-issuer)" \
       webdav-rclone-sidecar" &
 
     echo "$(oidc-token my-issuer)" >/tmp/token
-    docker run --privileged -it --rm --name oidcmount -v /tmp/webdav:/mnt:shared -v /tmp/token:/tmp/token
+    docker run --privileged -it --rm --name oidcmount -v /tmp/webdav:/mnt:shared -v /tmp/token:/tmp/token \
+      -e MOUNT_PATH="/mnt/subpath" \
+      -e MOUNT_WAIT_POINT="webdav-fs: /mnt fuse.rclone " \
       -e WEBDAV_URL="$WEBDAV_URL" \
       webdav-rclone-sidecar bearer_token_command="cat /tmp/token" &

--- a/webdav-rclone-sidecar/README.md
+++ b/webdav-rclone-sidecar/README.md
@@ -14,7 +14,7 @@ Using environment:
 * MOUNT\_OPTS: space separated additional arguments for *rclone mount* command
 * MOUNT\_PATH: mount path (default: */mnt*)
 * MOUNT\_WAIT: wait time for mountpoint in /proc/mounts (default: *20*)
-* MOUNT\_WAIT\_POINT: mountpoint regex to wait for (default: (empty))
+* MOUNT\_WAIT\_POINT: mountpoint regular expression to wait for (default: (empty))
 * VFS\_CACHE\_MODE: value for rclone VFS cache mode (off, minimal, writes, full) (default: *full*)
 
 Examples:

--- a/webdav-rclone-sidecar/mount.sh
+++ b/webdav-rclone-sidecar/mount.sh
@@ -13,10 +13,10 @@ VFS_CACHE_MODE=${VFS_CACHE_MODE:-full}
 if [ -n "$MOUNT_WAIT_POINT" ]; then
 	i=0
 	echo "Checking $MOUNT_WAIT_POINT ($MOUNT_PATH)..."
-	while ! grep "^$MOUNT_WAIT_POINT" /proc/mounts && test $i -lt $((2*MOUNT_WAIT)); do
+	while ! grep "^$MOUNT_WAIT_POINT" /proc/mounts && test $i -lt $((2 * MOUNT_WAIT)); do
 		echo "Waiting for $MOUNT_WAIT_POINT..."
 		sleep 0.5
-		i=$((i+1))
+		i=$((i + 1))
 	done
 fi
 

--- a/webdav-rclone-sidecar/mount.sh
+++ b/webdav-rclone-sidecar/mount.sh
@@ -5,9 +5,20 @@
 MOUNT_OPTS=${MOUNT_OPTS:-}
 # where to mount
 MOUNT_PATH=${MOUNT_PATH:-/mnt/}
+MOUNT_WAIT=${MOUNT_WAIT:-20}
 JOVYAN_UID=${JOVYAN_UID:-1000}
 JOVYAN_GRP=${JOVYAN_GRP:-100}
 VFS_CACHE_MODE=${VFS_CACHE_MODE:-full}
+
+if [ -n "$MOUNT_WAIT_POINT" ]; then
+	i=0
+	echo "Checking $MOUNT_WAIT_POINT ($MOUNT_PATH)..."
+	while ! grep "^$MOUNT_WAIT_POINT" /proc/mounts && test $i -lt $((2*MOUNT_WAIT)); do
+		echo "Waiting for $MOUNT_WAIT_POINT..."
+		sleep 0.5
+		i=$((i+1))
+	done
+fi
 
 if [ ! -d "$MOUNT_PATH" ]; then
 	mkdir -p "$MOUNT_PATH"


### PR DESCRIPTION
# Summary

There may be needed to mount subdirectories in remote home directory (in ownCloud we will need multiple endpoints and we don't have symlinks there).

In Kubernetes is not guaranteed order of the sidecar containers launching, so there may be needed to wait for the "main" sidecar container mounting the parent directory before mounting subdirectories.

Implemented is waiting for the mountpoint in `/proc/mounts`, when specified `MOUNT_WAIT_POINT` environment variable.

**Related issue :**
