### PR TITLE
Extra image for AI with elyra

### DIFF
--- a/.github/workflows/egi-images.yml
+++ b/.github/workflows/egi-images.yml
@@ -17,10 +17,11 @@ jobs:
         "single-user/Dockerfile"
         "single-user-panosc/Dockerfile"
         "single-user-ai4pp/Dockerfile"
+        "single-user-ai/Dockerfile"
 
   base-image:
     name: Build base image
-    needs: detect-changes 
+    needs: detect-changes
     if: needs.detect-changes.outputs.build-base == 1
     runs-on: ubuntu-latest
     outputs:

--- a/single-user-ai/Dockerfile
+++ b/single-user-ai/Dockerfile
@@ -1,0 +1,13 @@
+ARG BASE_IMAGE=eginotebooks/base:latest
+# hadolint ignore=DL3006
+FROM $BASE_IMAGE
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# not installable from mamba for now
+RUN pip install --no-cache-dir \
+        elyra
+
+RUN jupyter lab build
+
+RUN rmdir work

--- a/single-user-ai/Dockerfile
+++ b/single-user-ai/Dockerfile
@@ -4,6 +4,24 @@ FROM $BASE_IMAGE
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+RUN mamba install -y --quiet \
+        tensorflow \
+    && conda clean --all
+
+# See https://github.com/mamba-org/mamba/issues/336
+# pytorch is not installing properly with mamba
+RUN mamba install -y pytorch torchvision torchaudio cpuonly -c pytorch -c anaconda -c conda-forge \
+    && mamba install -y --quiet fastai -c fastai \
+    && conda clean --all
+
+# packages not in conda
+RUN pip install --no-cache-dir \
+        tflearn
+
+# not installable from mamba for now
+RUN pip install --no-cache-dir \
+        eo-learn
+
 # not installable from mamba for now
 RUN pip install --no-cache-dir \
         elyra

--- a/single-user/Dockerfile
+++ b/single-user/Dockerfile
@@ -39,11 +39,6 @@ RUN mamba install -y --quiet \
 RUN pip install --no-cache-dir \
         eo-learn
 
-# not installable from mamba for now
-# XXX: problem with dependency: pydantic
-RUN pip install --no-cache-dir \
-        elyra
-
 # See https://github.com/mamba-org/mamba/issues/336
 # pytorch is not installing properly with mamba
 RUN mamba install -y pytorch torchvision torchaudio cpuonly -c pytorch -c anaconda -c conda-forge \

--- a/single-user/Dockerfile
+++ b/single-user/Dockerfile
@@ -35,16 +35,6 @@ RUN mamba install -y --quiet \
         jupyter-resource-usage \
     && conda clean --all
 
-# not installable from mamba for now
-RUN pip install --no-cache-dir \
-        eo-learn
-
-# See https://github.com/mamba-org/mamba/issues/336
-# pytorch is not installing properly with mamba
-RUN mamba install -y pytorch torchvision torchaudio cpuonly -c pytorch -c anaconda -c conda-forge \
-    && mamba install -y --quiet fastai -c fastai \
-    && conda clean --all
-
 # Octave, install on a different environment
 # Octave from conda won't build packages
 # see https://discourse.jupyter.org/t/installing-octave-packages-with-binder/4206
@@ -92,8 +82,7 @@ RUN pip install --no-cache-dir \
         git+https://github.com/EGI-Foundation/egi-notebooks-addons@0.1.3 \
         h5glance \
         nbtop \
-	panel \
-        tflearn
+        panel
 
 # EMSO
 # python3.7, install on a different environment


### PR DESCRIPTION
# Summary

Creating extra AI image with Elyra to solve dependency problems in the single-user image - it will update there jupyterlab from 3.1.4 to 4.2.3.

There are some questions to consider yet:

* the name of the image is OK? (**single-user-ai**)
* other components to add?:
  * quantum SDK
  * eo-learn (originally added for JRC)
* `jupyter lab build` not needed anymore in single-user?

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
