### PR TITLE
Adding extension enabling use of Jupyterhub user sharing API

### DIFF
--- a/single-user-eosc/Dockerfile
+++ b/single-user-eosc/Dockerfile
@@ -69,7 +69,17 @@ RUN mamba install -y --quiet \
 RUN pip install --no-cache-dir \
         h5glance \
         nbtop \
-        panel
+        panel \
+        #User sharing extension, requires Jupyterhub 5,
+        #enabled sharing API and granted permission to 
+        #oauth token to be able to share an access to a server
+        #https://jupyterhub.readthedocs.io/en/stable/tutorial/sharing.html
+        git+https://gitlab.cesnet.cz/702/projekty/eosc-notebooks/user-sharing-extension
+
+#This needs to be run because for some reason, Jupyter server
+#does not list server extension without this command, even though
+#config for auto-enable is present in the extension
+RUN jupyter server extension enable user_sharing_extension
 
 # EOSC customisation
 # TODO: trigger image build on changes to these files


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary
This PR adds an extension for managing user sharing access API
Official doc [link](https://jupyterhub.readthedocs.io/en/stable/reference/sharing.html#sharing-reference)

<!-- Describe in plain English what this PR does -->

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
