### PR TITLE
Updated docker image for ecologicalrestorationlab

### DIFF
--- a/single-user-ecologicalrestorationlab/image-classification-demonstrator/Dockerfile
+++ b/single-user-ecologicalrestorationlab/image-classification-demonstrator/Dockerfile
@@ -16,5 +16,6 @@ RUN mamba install --yes \
     requests==2.32.3 \
     shapely==2.1.1 \
     termcolor==3.1.0 \
-    torchvision==0.22.0
+    torchvision==0.22.0 \
+    && pip install sqapi==0.58
 


### PR DESCRIPTION
This pull request comes from ticket: https://support.d4science.org/issues/29883

The PR updates the Dockerfile for the Image Classification Demonstrator in the Ecological Restoration Lab.