### PR TITLE
Hub 5.4.6

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -8,6 +8,10 @@
 # ubuntu-24.04.4
 FROM quay.io/jupyter/datascience-notebook:bc0e14e1b5a4
 
+#FIXME: remove this line when datascience-notebook
+#       with jupyterhub==5.4.6 is available 
+RUN pip install --no-cache-dir jupyterhub==5.4.6
+
 USER root
 
 RUN apt-get update \

--- a/single-user-ai4pp/Dockerfile
+++ b/single-user-ai4pp/Dockerfile
@@ -35,16 +35,18 @@ USER $NB_UID
 RUN mamba install -y --quiet octave_kernel=0.32.0 \
     && conda clean --all
 
+# FIXME: uncomment when unproper redirection is solved
+#        (Hub 5.4.6 is problematic)
 # Rstudio
-USER root
-RUN apt-get update \
-    && apt-get install -y gdebi-core \
-    && wget -q https://download2.rstudio.org/server/jammy/amd64/rstudio-server-2024.12.1-563-amd64.deb \
-    && gdebi -n rstudio-server-2024.12.1-563-amd64.deb \
-    && rm rstudio-server-2024.12.1-563-amd64.deb \
-    && apt-get remove -y gdebi \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+# USER root
+# RUN apt-get update \
+#     && apt-get install -y gdebi-core \
+#     && wget -q https://download2.rstudio.org/server/jammy/amd64/rstudio-server-2024.12.1-563-amd64.deb \
+#     && gdebi -n rstudio-server-2024.12.1-563-amd64.deb \
+#     && rm rstudio-server-2024.12.1-563-amd64.deb \
+#     && apt-get remove -y gdebi \
+#     && apt-get clean \
+#     && rm -rf /var/lib/apt/lists/*
 
 USER $NB_UID
 

--- a/single-user-eosc/Dockerfile
+++ b/single-user-eosc/Dockerfile
@@ -44,16 +44,18 @@ USER $NB_UID
 RUN mamba install -y --quiet octave_kernel=0.32.0 \
     && conda clean --all
 
+# FIXME: uncomment when unproper redirection is solved
+#        (Hub 5.4.6 is problematic)
 # Rstudio
-USER root
-RUN apt-get update \
-    && apt-get install -y gdebi-core \
-    && wget -q https://download2.rstudio.org/server/jammy/amd64/rstudio-server-2025.09.2-418-amd64.deb  \
-    && gdebi -n rstudio-server-2025.09.2-418-amd64.deb  \
-    && rm rstudio-server-2025.09.2-418-amd64.deb  \
-    && apt-get remove -y gdebi \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+# USER root
+# RUN apt-get update \
+#     && apt-get install -y gdebi-core \
+#     && wget -q https://download2.rstudio.org/server/jammy/amd64/rstudio-server-2025.09.2-418-amd64.deb  \
+#     && gdebi -n rstudio-server-2025.09.2-418-amd64.deb  \
+#     && rm rstudio-server-2025.09.2-418-amd64.deb  \
+#     && apt-get remove -y gdebi \
+#     && apt-get clean \
+#     && rm -rf /var/lib/apt/lists/*
 
 USER $NB_UID
 

--- a/single-user/Dockerfile
+++ b/single-user/Dockerfile
@@ -49,16 +49,18 @@ USER $NB_UID
 RUN mamba install -y --quiet octave_kernel=0.32.0 \
     && conda clean --all
 
+# FIXME: uncomment when unproper redirection is solved
+#        (Hub 5.4.6 is problematic)
 # Rstudio
-USER root
-RUN apt-get update \
-    && apt-get install -y gdebi-core \
-    && wget -q https://download2.rstudio.org/server/jammy/amd64/rstudio-server-2025.09.2-418-amd64.deb  \
-    && gdebi -n rstudio-server-2025.09.2-418-amd64.deb  \
-    && rm rstudio-server-2025.09.2-418-amd64.deb  \
-    && apt-get remove -y gdebi \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+# USER root
+# RUN apt-get update \
+#     && apt-get install -y gdebi-core \
+#     && wget -q https://download2.rstudio.org/server/jammy/amd64/rstudio-server-2025.09.2-418-amd64.deb  \
+#     && gdebi -n rstudio-server-2025.09.2-418-amd64.deb  \
+#     && rm rstudio-server-2025.09.2-418-amd64.deb  \
+#     && apt-get remove -y gdebi \
+#     && apt-get clean \
+#     && rm -rf /var/lib/apt/lists/*
 
 USER $NB_UID
 


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary
This PR adds Jupyterhub 5.4.6 into user image which is required to fix issues on the latest Jupyterhub release as described [here](https://github.com/jupyterlab/jupyterlab/issues/18839)  and also removes temporarily  Rstudio from images because with Jupyterhub 5.4.6 Rstudio will fail on too many redirections error