### PR TITLE
Temporarily remove jupyter-rsession-proxy

### DIFF
--- a/single-user-ai4pp/Dockerfile
+++ b/single-user-ai4pp/Dockerfile
@@ -50,9 +50,11 @@ RUN mamba install -y --quiet octave_kernel=0.32.0 \
 
 USER $NB_UID
 
-RUN mamba install -y --quiet \
-       -c conda-forge jupyter-rsession-proxy \
-    && conda clean --all
+#FIXME: uncomment when rstudio issue is fixed
+#       (Jupyterhub 5.4.6 is the problematic version)
+# RUN mamba install -y --quiet \
+#        -c conda-forge jupyter-rsession-proxy \
+#     && conda clean --all
 
 
 # packages not in conda

--- a/single-user-eosc/Dockerfile
+++ b/single-user-eosc/Dockerfile
@@ -59,9 +59,11 @@ RUN mamba install -y --quiet octave_kernel=0.32.0 \
 
 USER $NB_UID
 
-RUN mamba install -y --quiet \
-       -c conda-forge jupyter-rsession-proxy \
-    && conda clean --all
+#FIXME: uncomment when rstudio issue is fixed
+#       (Jupyterhub 5.4.6 is the problematic version)
+# RUN mamba install -y --quiet \
+#        -c conda-forge jupyter-rsession-proxy \
+#     && conda clean --all
 
 # packages not in conda or not their newest version
 RUN pip install --no-cache-dir \

--- a/single-user/Dockerfile
+++ b/single-user/Dockerfile
@@ -64,9 +64,11 @@ RUN mamba install -y --quiet octave_kernel=0.32.0 \
 
 USER $NB_UID
 
-RUN mamba install -y --quiet \
-       -c conda-forge jupyter-rsession-proxy \
-    && conda clean --all
+#FIXME: uncomment when rstudio issue is fixed
+#       (Jupyterhub 5.4.6 is the problematic version)
+# RUN mamba install -y --quiet \
+#        -c conda-forge jupyter-rsession-proxy \
+#     && conda clean --all
 
 # bioconda
 RUN conda config --add channels bioconda \


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary
This PR is related to this one, it removes Rstudio icon in the Jupyterlab before the issue is fixed https://github.com/EGI-Federation/egi-notebooks-images/pull/294

<img width="174" height="199" alt="image" src="https://github.com/user-attachments/assets/a01358b3-4fed-44e3-834a-5cb9e4bd9489" />
