### PR TITLE
Adding system-wide Rstudio download setting

### DIFF
--- a/single-user-ai4pp/Dockerfile
+++ b/single-user-ai4pp/Dockerfile
@@ -48,6 +48,10 @@ RUN apt-get update \
 
 USER $NB_UID
 
+# adds system-wide setting for rstudio to use wget instead libcurl
+RUN echo 'options(download.file.method = "wget")' >> /opt/conda/lib/R/etc/Rprofile.site
+
+
 # jupyter-rsession-proxy=2.5.0 breaks rstudio
 # option by invalid redirects
 RUN mamba install -y --quiet \

--- a/single-user-eosc/Dockerfile
+++ b/single-user-eosc/Dockerfile
@@ -57,6 +57,10 @@ RUN apt-get update \
 
 USER $NB_UID
 
+# adds system-wide setting for rstudio to use wget instead libcurl
+RUN echo 'options(download.file.method = "wget")' >> /opt/conda/lib/R/etc/Rprofile.site
+
+
 # jupyter-rsession-proxy=2.5.0 breaks rstudio
 # option by invalid redirects
 RUN mamba install -y --quiet \

--- a/single-user/Dockerfile
+++ b/single-user/Dockerfile
@@ -62,6 +62,9 @@ RUN apt-get update \
 
 USER $NB_UID
 
+# adds system-wide setting for rstudio to use wget instead libcurl
+RUN echo 'options(download.file.method = "wget")' >> /opt/conda/lib/R/etc/Rprofile.site
+
 # jupyter-rsession-proxy=2.5.0 breaks rstudio
 # option by invalid redirects
 RUN mamba install -y --quiet \


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary
This PR adds Rstudio global option to switch to wget instead of libcurl 