### PR TITLE
Add ApricotLAB to single-user image

### DIFF
--- a/single-user/Dockerfile
+++ b/single-user/Dockerfile
@@ -93,7 +93,9 @@ RUN pip install --no-cache-dir \
         git+https://gitlab.cesnet.cz/702/projekty/eosc-notebooks/user-sharing-extension \
         # quantum SDKs
         dwave-ocean-sdk \
-        pennylane
+        pennylane \
+        # Apricotlab
+        git+https://github.com/grycap/apricotlab.git@main
 
 # EMSO
 # python3.7, install on a different environment


### PR DESCRIPTION
## Summary

This PR adds ApricotLAB to the `single-user` image.

The integration uses the upstream ApricotLAB repository without any local modifications or workarounds. The package is installed directly during the image build, making ApricotLAB available in EGI Notebooks.

At the moment, the installation is performed from the `main` branch because it contains the latest fixes required for ApricotLAB to build and function correctly. Once these changes are included in an official release, the installation can be updated to use a tagged version instead.

## Testing

The image was built successfully and tested on the EGI development deployment.

Basic functionality verified:
- ApricotLAB installation
- JupyterLab startup
- Deployment List UI
- Infrastructure deployment using the supported templates