### PR TITLE
Trigerring build to get latest share-manager extension versions

### DIFF
--- a/single-user-eosc/Dockerfile
+++ b/single-user-eosc/Dockerfile
@@ -77,8 +77,8 @@ RUN pip install --no-cache-dir \
         tensorflow \
         sisl[viz] \
         # share-manager extensions
-        git+https://gitlab.cesnet.cz/702/projekty/eosc-notebooks/jupyterlab-token-acquirer \
         git+https://gitlab.cesnet.cz/702/projekty/eosc-notebooks/user-sharing-extension \
+        git+https://gitlab.cesnet.cz/702/projekty/eosc-notebooks/jupyterlab-token-acquirer \
         # File Sync & Sharing health status extension
         git+https://gitlab.cesnet.cz/702/projekty/eosc-notebooks/owncloud-mount-health-extension \
         git+https://github.com/dipc-cc/hubbard.git


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

This PR only triggers build of EOSC user image to pull latest versions of share-manager extensions
